### PR TITLE
Don't act on empty nova_instances list

### DIFF
--- a/scripts/cinder-consistency.py
+++ b/scripts/cinder-consistency.py
@@ -61,6 +61,9 @@ def get_nova_instances(conn):
     #for i in nova_instances:
     #    print nova_instances[i].id
 
+    if not nova_instances:
+        raise RuntimeError('Did not get any nova instances back.')
+
     return nova_instances
 
 # get all volume attachments for volumes


### PR DESCRIPTION
Nova seems to sometimes return an empty list of instances instead of an
error. We cannot act on an empty list and thus have to bail.