### PR TITLE
[cinder] fix quota sync for projects without volumes

### DIFF
--- a/scripts/cinder-quota-sync.py
+++ b/scripts/cinder-quota-sync.py
@@ -41,9 +41,9 @@ def get_projects(meta):
     """Return a list of all projects in the database"""
 
     projects = []
-    volumes_t = Table('volumes', meta, autoload=True)
-    volumes_q = select(columns=[volumes_t.c.project_id]). group_by(volumes_t.c.project_id)
-    for project in volumes_q.execute():
+    quota_usages_t = Table('quota_usages', meta, autoload=True)
+    quota_usages_q = select(columns=[quota_usages_t.c.project_id]). group_by(quota_usages_t.c.project_id)
+    for project in quota_usages_q.execute():
         projects.append(project[0])
 
     return projects


### PR DESCRIPTION
cinder quota can be wrong in a project, even if it has no volumes:
e.g. quota got out of sync when deleting everything.
So let's generate the project list out of the quota_usages table, it is being
operated on that table anyhow.

error was observed and fixed in manila, follow the same pattern like
f945b00f3ce929f46faebfaaf555540e1b7b9459