### PR TITLE
[nova-consistency] ignore block_device_mappings with null volume_id

### DIFF
--- a/scripts/nova-consistency.py
+++ b/scripts/nova-consistency.py
@@ -70,7 +70,10 @@ def get_block_device_mappings(meta):
 
     block_device_mappings = {}
     block_device_mapping_t = Table('block_device_mapping', meta, autoload=True)
-    block_device_mapping_q = select(columns=[block_device_mapping_t.c.id, block_device_mapping_t.c.volume_id],whereclause=and_(block_device_mapping_t.c.deleted == 0, block_device_mapping_t.c.destination_type == "volume"))
+    block_device_mapping_q = select(columns=[block_device_mapping_t.c.id, block_device_mapping_t.c.volume_id],
+                                    whereclause=and_(block_device_mapping_t.c.deleted == 0,
+                                                     block_device_mapping_t.c.volume_id.isnot(None),
+                                                     block_device_mapping_t.c.destination_type == "volume"))
 
     # return a dict indexed by block_device_mapping_id and with the value cinder_volume_id for non deleted block_device_mappings
     for (block_device_mapping_id, cinder_volume_id) in block_device_mapping_q.execute():


### PR DESCRIPTION
There are cases when a boot-from-volume instance is being created,
so nova first creates the BDMs in the DB before creating a volume.
Once the volume is created, nova will update the BDM with volume_id.
Meanwhile, nanny might have already mark that BDM as deleted since
the volume_id was None and it was not found in the volume list.

This issue was also seen in the logs as follows:
`block device mapping (id in nova db: <id>) for non existent volume in cinder: None`