### PR TITLE
nova-instance-mapping: Fix always match first cell

### DIFF
--- a/scripts/nova-queens-instance-mapping.py
+++ b/scripts/nova-queens-instance-mapping.py
@@ -108,9 +108,9 @@ for (instance_uuid,) in unmapped_instances:
 
   # Check which cell contains this instance
   for cell in CELLS:
-    cell['db'].cursor(buffered=True).execute("SELECT id FROM instances WHERE uuid = %s", (instance_uuid,))
-
-    if cell['db'].cursor(buffered=True).rowcount != 0:
+    cell_cur = cell['db'].cursor(buffered=True)
+    cell_cur.execute("SELECT id FROM instances WHERE uuid = %s", (instance_uuid,))
+    if cell_cur.rowcount != 0:
       instance_cell = cell
       break
 


### PR DESCRIPTION
When finding the cell for an instance a cursor is rightfully created
for running the query, but when checking the rowcount to see if any
instances matched, a new cursor was created. New cursors still have
rowcount > 0 (presumably some query is run when creating the cursor).
This made the first checked cell always match and put all instances
with NULL cell_mapping into the same first cell, regardless of the
actual cell they're in.

Create the cursor separately and use it for query and rowcount-check.
