### PR TITLE
[prometheus_exporter] init metric with value 0

### DIFF
--- a/nannies/helper/prometheus_exporter.py
+++ b/nannies/helper/prometheus_exporter.py
@@ -95,6 +95,8 @@ class LabelGauge:
 
     def __init__(self, name, helper, labels):
         self._gauge = Gauge(name, helper, labels)
+        # init empty metric to distinguish from absent metric
+        self._gauge.labels(**{label: 'none' for label in labels}).set(0)
         self._labelkey_cache = {}
 
     def export(self, data):


### PR DESCRIPTION
export something to be able to distinguish from a missing metric

e.g. 'manila_nanny_missing_snapshot_instance' would only be visible if there where any snapshots missing, but we would not know how to notice the difference from a non-working metric