### PR TITLE
The SafeConfigParser class has been renamed to ConfigParser in Python 3.2

### DIFF
--- a/nannies/cinder-consistency.py
+++ b/nannies/cinder-consistency.py
@@ -486,7 +486,7 @@ def makeConnection(db_url):
 
 # return the database connection string from the config file
 def get_db_url(config_file):
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/nannies/cinder-quota-sync.py
+++ b/nannies/cinder-quota-sync.py
@@ -169,7 +169,7 @@ def get_db_url(config_file):
 
     """Return the database connection string from the config file"""
 
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/nannies/count-deleted.py
+++ b/nannies/count-deleted.py
@@ -69,7 +69,7 @@ def makeConnection(db_url):
 # return the database connection string from the config file
 def get_db_url(config_file):
 
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/nannies/vcenter_consistency_module.py
+++ b/nannies/vcenter_consistency_module.py
@@ -784,7 +784,7 @@ class ConsistencyCheck:
     # return the database connection string from the config file
     def get_db_url(self, config_file):
 
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         try:
             parser.read(config_file)
             db_url = parser.get('database', 'connection', raw=True)
@@ -941,7 +941,7 @@ class ConsistencyCheck:
 
         try:
             db_url = self.get_db_url(self.novaconfig)
-            
+
             self.nova_engine = create_engine(db_url, pool_pre_ping=True)
             self.nova_connection = self.nova_engine.connect()
             Session = sessionmaker(bind=self.nova_engine)

--- a/scripts/count-deleted.py
+++ b/scripts/count-deleted.py
@@ -69,7 +69,7 @@ def makeConnection(db_url):
 # return the database connection string from the config file
 def get_db_url(config_file):
 
-    parser = ConfigParser.SafeConfigParser()
+    parser = ConfigParser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/scripts/manila-consistency.py
+++ b/scripts/manila-consistency.py
@@ -271,7 +271,7 @@ def makeConnection(db_url):
 # return the database connection string from the config file
 def get_db_url(config_file):
 
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/scripts/manila-quota-sync.py
+++ b/scripts/manila-quota-sync.py
@@ -227,7 +227,7 @@ class ManilaQuotaSyncNanny(ManilaNanny):
 
 def get_db_url(config_file):
     """Return the database connection string from the config file"""
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/scripts/neutron-cleanup-pending-lb.py
+++ b/scripts/neutron-cleanup-pending-lb.py
@@ -102,7 +102,7 @@ class NeutronLbaasCleanupPending:
     # return the database connection string from the config file
     def get_db_url(self):
 
-        parser = ConfigParser.SafeConfigParser()
+        parser = ConfigParser.ConfigParser()
         try:
             parser.read(self.args.config)
             self.db_url = parser.get('database', 'connection', raw=True)
@@ -123,7 +123,7 @@ class NeutronLbaasCleanupPending:
             pending_lbaas_loadbalancers.append(i[0])
 
         return pending_lbaas_loadbalancers
-    
+
     # init dict of all vms or files we have seen already
     def init_seen_dict(self):
         for i in self.seen_dict:

--- a/scripts/nova-consistency.py
+++ b/scripts/nova-consistency.py
@@ -226,7 +226,7 @@ def makeConnection(db_url):
 # return the database connection string from the config file
 def get_db_url(config_file):
 
-    parser = ConfigParser.SafeConfigParser()
+    parser = ConfigParser.ConfigParser()
     try:
         parser.read(config_file)
         db_url = parser.get('database', 'connection', raw=True)

--- a/scripts/nova-queens-instance-mapping.py
+++ b/scripts/nova-queens-instance-mapping.py
@@ -49,7 +49,7 @@ def dsn_to_args(api_db_url):
 
 
 def get_api_db_url(config_file):
-  parser = ConfigParser.SafeConfigParser()
+  parser = ConfigParser.ConfigParser()
   try:
     parser.read(config_file)
     api_db_url = parser.get('api_database', 'connection', raw=True)

--- a/scripts/nova-sync-neutron-cache.py
+++ b/scripts/nova-sync-neutron-cache.py
@@ -90,7 +90,7 @@ class NovaInstanceInfoCacheSync:
     # return the database connection string from the config file
     def get_db_url(self):
 
-        parser = ConfigParser.SafeConfigParser()
+        parser = ConfigParser.ConfigParser()
         try:
             parser.read(self.args.config)
             self.db_url = parser.get('database', 'connection', raw=True)


### PR DESCRIPTION
… 3.2

see https://github.com/python/cpython/blob/main/Doc/whatsnew/3.2.rst#configparser