### PR TITLE
[manila] use microversion 2.19 for snapshot instances

### DIFF
--- a/scripts/manila-share-snapshot.py
+++ b/scripts/manila-share-snapshot.py
@@ -52,7 +52,8 @@ class ManilaShareSnapshotNanny(ManilaNanny):
                                                        interval,
                                                        prom_port=prom_port,
                                                        http_port=http_port,
-                                                       handler=handler)
+                                                       handler=handler,
+                                                       version="2.19")
         self.orphan_snapshots_lock = Lock()
         self.orphan_snapshots: Dict[str, Dict[str, str]] = {}
         self.orphan_snapshots_gauge = Gauge('manila_nanny_orphan_share_snapshots',

--- a/scripts/manilananny.py
+++ b/scripts/manilananny.py
@@ -23,12 +23,13 @@ log = logging.getLogger(__name__)
 
 class ManilaNanny(http.server.HTTPServer):
     ''' Manila Nanny '''
-    def __init__(self, config_file, interval, dry_run=False, prom_port=0, address="", http_port=8000, handler=None):
+    def __init__(self, config_file, interval, dry_run=False, prom_port=0, address="", http_port=8000, handler=None, version="2.7"):
         self.config_file = config_file
         self.interval = interval
         self.dry_run = dry_run
+        self.microversion = version
         self.init_db_connection()
-        self.manilaclient = create_manila_client(config_file)
+        self.manilaclient = create_manila_client(config_file, self.microversion)
 
         if prom_port != 0:
             try:
@@ -76,7 +77,7 @@ class ManilaNanny(http.server.HTTPServer):
         return db_url
 
     def renew_manila_client(self):
-        self.manilaclient = create_manila_client(self.config_file, "2.7")
+        self.manilaclient = create_manila_client(self.config_file, self.microversion)
 
     def undefined_route(self, route):
         status_code = 500
@@ -184,7 +185,7 @@ class ManilaNanny(http.server.HTTPServer):
                           snapshot_id, e)
 
 
-def create_manila_client(config_file, version="2.7"):
+def create_manila_client(config_file, version):
     """  Parse config file and create manila client
 
         :param string config_file:


### PR DESCRIPTION
minimum required version per
https://docs.openstack.org/api-ref/shared-file-system/#share-snapshot-instances-since-api-v2-19

fixes #76