### PR TITLE
[manila] snapshot quota usage: only count once per snapshot

### DIFF
--- a/scripts/manila-quota-sync.py
+++ b/scripts/manila-quota-sync.py
@@ -59,7 +59,7 @@ class ManilaQuotaSyncNanny(ManilaNanny):
                              whereclause=and_(snapshots_t.c.deleted == "False",
                                               snapshots_t.c.project_id == project_id,
                                               share_instances_t.c.deleted == "False")
-                             ).select_from(q)
+                             ).select_from(q).group_by(snapshots_t.c.id)
         return snapshots_q.execute()
 
     def get_share_usages_project(self, project_id):


### PR DESCRIPTION
That reflects how manila is determining snapshot quota on creating
a snapshot. Snapshot instances belonging to non-active share replicas
are not taken into account.

The quota sync was created before the replication feature was
introduced. That is why this was not considered probably.

We are okay with not setting quota usage for non-active snapshots,
because the quota usage is anyhow a lot higher than physical used
storage space by snapshots in most cases.


- [x] tested in qa
