### PR TITLE
[manila] use additional secret config

### DIFF
--- a/nannies/helper/manilananny.py
+++ b/nannies/helper/manilananny.py
@@ -105,8 +105,12 @@ def base_command_parser():
 
     The returned parser can be extended by its add_argument() method.
     """
+    default_config_files = os.environ.get('MANILA_NANNY_CONFIG') or ["/etc/manila/manila.conf", "/etc/manila/secrets.conf"]
+    default_interval = os.environ.get('MANILA_NANNY_INTERVAL') or 3600
+    default_prom_port = os.environ.get('MANILA_NANNY_PROMETHEUS_PORT') or 9000
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default="/manila-etc/manila.conf", help="configuration file")
-    parser.add_argument("--interval", type=float, default=600, help="interval in seconds")
-    parser.add_argument("--prom-port", type=int, default=9000, help="prometheus exporter port")
+    parser.add_argument("--config", action="append", default=default_config_files, help="configuration file(s)")
+    parser.add_argument("--interval", type=float, default=default_interval, help="interval in seconds")
+    parser.add_argument("--prom-port", type=int, default=default_prom_port, help="prometheus exporter port")
     return parser

--- a/nannies/manila-missing-snapshot.py
+++ b/nannies/manila-missing-snapshot.py
@@ -17,6 +17,7 @@
 #
 import configparser
 import logging
+import os
 import sys
 
 import manilaclient.common.apiclient.exceptions as manilaexceptions
@@ -215,7 +216,8 @@ def list_share_snapshots(netappclient: NetAppRestHelper):
 
 def main():
     parser = base_command_parser()
-    parser.add_argument("--netapp-filers", default="/manila-etc/netapp-filers.yaml",
+    default_netapp_filers = os.environ.get('MANILA_NANNY_NETAPP_FILERS') or "/etc/manila/netapp-filers.yaml"
+    parser.add_argument("--netapp-filers", default=default_netapp_filers,
                         help="Netapp filers list")
     args = parser.parse_args()
 

--- a/nannies/manila-missing-snapshot.sh
+++ b/nannies/manila-missing-snapshot.sh
@@ -14,20 +14,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-# 
+#
 
 set -e
 set -u
 
 unset http_proxy https_proxy all_proxy no_proxy
 
-
 echo "INFO: exporting missing snapshots"
-/var/lib/openstack/bin/python /scripts/manila-missing-snapshot.py \
-    --config $MANILA_NANNY_CONFIG \
-    --netapp-filers $MANILA_NANNY_NETAPP_FILERS \
-    --interval $MANILA_NANNY_INTERVAL \
-    --prom-port $MANILA_NANNY_PROMETHEUS_PORT
+/var/lib/openstack/bin/python /scripts/manila-missing-snapshot.py
 
 # start a test command
 # /var/lib/openstack/bin/python /scripts/manila-missing-snapshot.py --prom-port 9605

--- a/scripts/manila-check-affinity.py
+++ b/scripts/manila-check-affinity.py
@@ -15,11 +15,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 #
-import argparse
 import logging
-import os
 
 from helper.prometheus_exporter import LabelGauge
+from helper.manilananny import base_command_parser
 from manilananny import ManilaNanny
 
 LOG = logging.getLogger(__name__)
@@ -117,14 +116,7 @@ class ManilaCheckAffinity(ManilaNanny):
 
 if __name__ == "__main__":
 
-    default_config_file = os.environ.get('MANILA_NANNY_CONFIG') or '/etc/manila/manila.conf'
-    default_interval = os.environ.get('MANILA_NANNY_INTERVAL') or 3600
-    default_prom_port = os.environ.get('MANILA_NANNY_PROMETHEUS_PORT') or 9000
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", dest="config_file", default=default_config_file, help="configuration file")
-    parser.add_argument("--interval", type=int, default=default_interval, help="interval")
+    parser = base_command_parser()
     parser.add_argument("--pdb-port", type=int, default=50000, help="port for pdb_attach server")
-    parser.add_argument("--prom-port", type=int, default=default_prom_port, help="port for prometheus exporter")
 
     ManilaCheckAffinity(**vars(parser.parse_args())).run()

--- a/scripts/manila-consistency.py
+++ b/scripts/manila-consistency.py
@@ -17,7 +17,6 @@
 #
 # this script checks for inconsistencies in the manila db
 
-import argparse
 import configparser
 import datetime
 import logging
@@ -27,6 +26,8 @@ from openstack import connection, exceptions
 from sqlalchemy import (MetaData, Table, and_, create_engine, select, update)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+from helper.manilananny import base_command_parser
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)-15s %(message)s')
@@ -310,10 +311,7 @@ def _get_openstack_client(config_file):
 
 # cmdline handling
 def parse_cmdline_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config",
-                        default='./manila.conf',
-                        help='configuration file')
+    parser = base_command_parser()
     parser.add_argument("--dry-run",
                         action="store_true",
                         help='print only what would be done without actually doing it')

--- a/scripts/manila-db-consistency-and-purge.sh
+++ b/scripts/manila-db-consistency-and-purge.sh
@@ -20,9 +20,6 @@ set -e
 
 unset http_proxy https_proxy all_proxy no_proxy
 
-echo "INFO: copying manila config files to /etc/manila"
-cp -v /manila-etc/* /etc/manila
-
 # we run an endless loop to run the script periodically
 echo "INFO: starting a loop to periodically run the nanny job for the manila db consistency check and purge"
 while true; do
@@ -30,11 +27,11 @@ while true; do
         if [ "$MANILA_CONSISTENCY_DRY_RUN" = "False" ] || [ "$MANILA_CONSISTENCY_DRY_RUN" = "false" ]; then
             echo -n "INFO: checking and fixing manila db consistency - "
             date
-            /var/lib/openstack/bin/python /scripts/manila-consistency.py --config /etc/manila/manila.conf --older-than ${MANILA_CONSISTENCY_OLDER_THAN:-2}
+            /var/lib/openstack/bin/python /scripts/manila-consistency.py --older-than ${MANILA_CONSISTENCY_OLDER_THAN:-2}
         else
             echo -n "INFO: checking manila db consistency - "
             date
-            /var/lib/openstack/bin/python /scripts/manila-consistency.py --config /etc/manila/manila.conf --older-than ${MANILA_CONSISTENCY_OLDER_THAN:-2} --dry-run
+            /var/lib/openstack/bin/python /scripts/manila-consistency.py --older-than ${MANILA_CONSISTENCY_OLDER_THAN:-2} --dry-run
         fi
     fi
     if [ "$MANILA_DB_PURGE_ENABLED" = "True" ] || [ "$MANILA_DB_PURGE_ENABLED" = "true" ]; then

--- a/scripts/manila-quota-sync.py
+++ b/scripts/manila-quota-sync.py
@@ -17,7 +17,6 @@
 #
 # based on https://github.com/cernops/cinder-quota-sync
 
-import argparse
 import configparser
 import datetime
 import logging
@@ -28,6 +27,7 @@ from prettytable import PrettyTable
 from prometheus_client import Counter, start_http_server
 from sqlalchemy import Table, and_, func, select, update
 
+from helper.manilananny import base_command_parser
 from manilananny import ManilaNanny
 
 logHandler = logging.StreamHandler()
@@ -419,21 +419,10 @@ def get_db_url(config_file):
 
 def main():
     try:
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--config",
-                            default='./manila.conf',
-                            help='configuration file')
+        parser = base_command_parser()
         parser.add_argument("--dry-run",
                             action="store_true",
                             help="never sync resources (no interactive check)")
-        parser.add_argument("--interval",
-                            default=600,
-                            type=float,
-                            help="interval")
-        parser.add_argument("--promport",
-                            default=9456,
-                            type=int,
-                            help="prometheus port")
         args = parser.parse_args()
     except Exception as e:
         sys.stdout.write("Check command line arguments (%s)" % e)
@@ -441,7 +430,7 @@ def main():
     print(args)
 
     try:
-        start_http_server(args.promport)
+        start_http_server(args.prom_port)
     except Exception as e:
         logging.fatal("start_http_server: %s", e)
         sys.exit(-1)

--- a/scripts/manila-quota-sync.sh
+++ b/scripts/manila-quota-sync.sh
@@ -20,16 +20,13 @@ set -e
 
 unset http_proxy https_proxy all_proxy no_proxy
 
-echo "INFO: copying manila config files to /etc/manila"
-cp -v /manila-etc/* /etc/manila
-
 # we run an endless loop to run the script periodically
 if [ "$MANILA_QUOTA_SYNC_ENABLED" = "True" ] || [ "$MANILA_QUOTA_SYNC_ENABLED" = "true" ]; then
     if [ "$MANILA_QUOTA_SYNC_DRY_RUN" = "False" ] || [ "$MANILA_QUOTA_SYNC_DRY_RUN" = "false" ]; then
         echo "INFO: run nanny job for the manila quota sync"
-        /var/lib/openstack/bin/python /scripts/manila-quota-sync.py --config /etc/manila/manila.conf --interval $MANILA_NANNY_INTERVAL
+        /var/lib/openstack/bin/python /scripts/manila-quota-sync.py
     else
         echo "INFO: run nanny job for the manila quota sync in dry-run mode only!"
-        /var/lib/openstack/bin/python /scripts/manila-quota-sync.py --config /etc/manila/manila.conf --interval $MANILA_NANNY_INTERVAL --dry-run
+        /var/lib/openstack/bin/python /scripts/manila-quota-sync.py --dry-run
     fi
 fi

--- a/scripts/manila-share-server.py
+++ b/scripts/manila-share-server.py
@@ -15,7 +15,6 @@
 #
 from __future__ import absolute_import
 
-import argparse
 from http.server import BaseHTTPRequestHandler
 from threading import Lock
 from typing import Dict, List, Tuple
@@ -23,6 +22,7 @@ from typing import Dict, List, Tuple
 from prometheus_client import Gauge
 from sqlalchemy import Table, and_, func, select
 
+from helper.manilananny import base_command_parser
 from manilananny import ManilaNanny, response, update_records
 
 
@@ -93,11 +93,8 @@ class ManilaShareServerNanny(ManilaNanny):
 
 
 def parse_cmdline_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default='/etc/manila/manila.conf', help='configuration file')
-    parser.add_argument("--interval", type=float, default=3600, help="interval")
+    parser = base_command_parser()
     parser.add_argument("--listen-port", type=int, default=8000, help="http server listen port")
-    parser.add_argument("--prom-port", type=int, default=9000, help="http server listen port")
     return parser.parse_args()
 
 

--- a/scripts/manila-share-server.sh
+++ b/scripts/manila-share-server.sh
@@ -14,20 +14,14 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-# 
+#
 
 set -e
 set -u
 
 unset http_proxy https_proxy all_proxy no_proxy
 
-echo "INFO: copying manila config files to /etc/manila"
-cp -v /manila-etc/* /etc/manila
-
 echo "INFO: working on manila share server"
 /var/lib/openstack/bin/python /scripts/manila-share-server.py \
-    --config /etc/manila/manila.conf \
-    --interval $MANILA_NANNY_INTERVAL \
-    --prom-port $MANILA_NANNY_PROMETHEUS_PORT \
     --listen-port $MANILA_NANNY_LISTEN_PORT
 

--- a/scripts/manila-share-snapshot.py
+++ b/scripts/manila-share-snapshot.py
@@ -21,6 +21,7 @@ from http.server import BaseHTTPRequestHandler
 from threading import Lock
 from typing import Dict
 
+from helper.manilananny import base_command_parser
 from manilananny import ManilaNanny, is_utcts_recent, response, update_records
 from prometheus_client import Gauge
 from sqlalchemy import Table, select
@@ -218,11 +219,8 @@ def str2bool(val):
 
 
 def parse_cmdline_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default='/etc/manila/manila.conf', help='configuration file')
-    parser.add_argument("--interval", type=float, default=3600, help="interval")
+    parser = base_command_parser()
     parser.add_argument("--listen-port", type=int, default=8000, help="http server listen port")
-    parser.add_argument("--prom-port", type=int, default=9000, help="http server listen port")
     parser.add_argument("--task-share-snapshot-state", type=str2bool, default=False,
                         help="enable share snapshot state task")
     parser.add_argument("--task-share-snapshot-state-dry-run", type=str2bool, default=False,

--- a/scripts/manila-share-snapshot.sh
+++ b/scripts/manila-share-snapshot.sh
@@ -14,21 +14,15 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-# 
+#
 
 set -e
 set -u
 
 unset http_proxy https_proxy all_proxy no_proxy
 
-echo "INFO: copying manila config files to /etc/manila"
-cp -v /manila-etc/* /etc/manila
-
 echo "INFO: working on manila share snapshot"
 /var/lib/openstack/bin/python /scripts/manila-share-snapshot.py \
-    --config /etc/manila/manila.conf \
-    --interval $MANILA_NANNY_INTERVAL \
-    --prom-port $MANILA_NANNY_PROMETHEUS_PORT \
     --listen-port $MANILA_NANNY_LISTEN_PORT \
     --task-share-snapshot-state $TASK_SHARE_SNAPSHOT_STATE \
     --task-share-snapshot-state-dry-run $TASK_SHARE_SNAPSHOT_STATE_DRY_RUN

--- a/scripts/manila-share-sync.py
+++ b/scripts/manila-share-sync.py
@@ -30,6 +30,7 @@ import requests
 from prometheus_client import Counter, Gauge
 from sqlalchemy import Table, select, update
 
+from helper.manilananny import base_command_parser
 from manilananny import CustomAdapter, ManilaNanny, is_utcts_recent, response, update_records
 
 log = logging.getLogger('nanny-manila-share-sync')
@@ -726,10 +727,7 @@ def str2bool(val):
 
 
 def parse_cmdline_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default='/manila-etc/manila.conf', help='configuration file')
-    parser.add_argument("--interval", type=float, default=600, help="interval")
-    parser.add_argument("--prom-port", type=int, default=9000, help="prometheus port")
+    parser = base_command_parser()
     parser.add_argument("--netapp-prom-host",
                         default='http://prometheus-storage.infra-monitoring.svc:9090',
                         help="prometheus host for netapp metrics")

--- a/scripts/manila-share-sync.sh
+++ b/scripts/manila-share-sync.sh
@@ -14,22 +14,16 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-# 
+#
 
 set -e
 set -u
 
 unset http_proxy https_proxy all_proxy no_proxy
 
-echo "INFO: copying manila config files to /etc/manila"
-cp -v /manila-etc/* /etc/manila
-
 echo "INFO: syncing between manila share and backend"
 /var/lib/openstack/bin/python /scripts/manila-share-sync.py \
-    --config /etc/manila/manila.conf \
     --netapp-prom-host $PROMETHEUS_HOST \
-    --prom-port $MANILA_NANNY_PROMETHEUS_PORT \
-    --interval $MANILA_NANNY_INTERVAL \
     --task-share-size $TASK_SHARE_SIZE \
     --task-share-size-dry-run $TASK_SHARE_SIZE_DRY_RUN \
     --task-missing-volume $TASK_MISSING_VOLUME \

--- a/scripts/manilananny.py
+++ b/scripts/manilananny.py
@@ -25,13 +25,13 @@ log = logging.getLogger(__name__)
 
 class ManilaNanny(http.server.HTTPServer):
     ''' Manila Nanny '''
-    def __init__(self, config_file, interval, dry_run=False, prom_port=0, address="", http_port=8000, handler=None, version="2.65", **extra_args):
-        self.config_file = config_file
+    def __init__(self, config, interval, dry_run=False, prom_port=0, address="", http_port=8000, handler=None, version="2.65", **extra_args):
+        self.config_file = config
         self.interval = interval
         self.dry_run = dry_run
         self.microversion = version
         self.init_db_connection()
-        self.manilaclient = create_manila_client(config_file, self.microversion)
+        self.manilaclient = create_manila_client(config, self.microversion)
 
         if prom_port != 0:
             try:


### PR DESCRIPTION
via argparse `action="append"` config is now a list,
which is understood by configparser.

Share base_command_parser() across all manila nannies
with common options.
