### PR TITLE
[manila] reset state on stuck resizing (2)

### DIFF
--- a/scripts/manila-share-sync.py
+++ b/scripts/manila-share-sync.py
@@ -233,10 +233,8 @@ class ManilaShareSyncNanny(ManilaNanny):
                     self.share_force_delete(share_id)
                     continue
 
-                if share_status == 'extending':
-                    self.share_reset_state(share_id, 'extending_error')
-                elif share_status == 'shrinking':
-                    self.share_reset_state(share_id, 'shrinking_error')
+                if share_status in ['extending', 'shrinking']:
+                    self.share_reset_state(share_id, 'available')
                 elif share_status in ['creating', 'deleting']:
                     self.share_reset_state(share_id, 'error')
                     if share_status == 'deleting':


### PR DESCRIPTION
stuck transitional states will be set to available since respective error states can be updated via API for non cloud admin.

Important for castellum to re-try the resizing.